### PR TITLE
fix update to 2.2.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-upload_channels:
-  - sfe1ed40
-channels:
-  - sfe1ed40


### PR DESCRIPTION
remove `abs.yaml` as it was not removed in pr #3.