### PR TITLE
update to 2.2.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+upload_channels:
+  - sfe1ed40
+channels:
+  - sfe1ed40

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,4 @@
-upload_channels:
-  - sfe1ed40
-channels:
-  - sfe1ed40
+# upload_channels:
+#   - sfe1ed40
+# channels:
+#   - sfe1ed40

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,4 @@
-# upload_channels:
-#   - sfe1ed40
-# channels:
-#   - sfe1ed40
+upload_channels:
+  - sfe1ed40
+channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,6 @@ build:
   skip: True  # [py<36]
   number: 0
   script: {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation
-  noarch: python
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,8 @@ requirements:
     - setuptools
   run:
     - nltk
-    - numpy
+    - numpy  # [not (linux and x86_64)]
+    - numpy >=1.22  # [linux and x86_64]
     - python
     - scikit-learn
     - scipy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
   skip: True  # [((osx and x86_64) or win-64) and py>310]
   skip: True  # [py<36]
   number: 0
-  script: {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,8 @@ requirements:
     - setuptools
   run:
     - nltk
-    - numpy
+    - numpy  # [not (linux and x86_64)]
+    - numpy >=1.22  # [linux and x86_64]
     - python
     - scikit-learn
     - scipy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,9 @@ source:
 
 build:
   # skip s390x and ppc64le because torchvision does not support these
-  skip: True  # [linux and (s390x or ppc64le)]
+  skip: True  # [linux and ppc64le and py>310]
+  skip: True  # [linux and s390x and py!=310]
+  skip: True  # [((osx and x86_64) or win-64) and py>310]
   skip: True  # [py<36]
   number: 0
   script: {{ PYTHON }} -m pip install . -vvv --no-deps --no-build-isolation

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,7 @@ source:
 
 build:
   # skip s390x and ppc64le because torchvision does not support these
-  skip: True  # [linux and ppc64le and py>310]
-  skip: True  # [linux and s390x and py!=310]
+  skip: True  # [linux and (ppc64le or s390x)]
   skip: True  # [((osx and x86_64) or win-64) and py>310]
   skip: True  # [py<36]
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,7 @@ requirements:
     - setuptools
   run:
     - nltk
-    - numpy  # [not (linux and x86_64)]
-    - numpy >=1.22  # [linux and x86_64]
+    - numpy
     - python
     - scikit-learn
     - scipy


### PR DESCRIPTION
This PR is here to fix #3 (which was built for `noarch`). Because it hasn't been uploaded to the SF channel, this is the opportunity to do so.

Reviewed:
* Changelog
* conda-forge recipe
* upstream project requirements
* license and about section
* `torchvision` is the major blocker for most missing platforms/py-versions and has been recently updated in [PR#11](https://github.com/AnacondaRecipes/torchvision-feedstock/pull/11).