### PR TITLE
[PKG-2603] Rebuild sentence-transformers 2.2.2 for py311 support  :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,2 @@
-upload_without_merge: true
-
 upload_channels:
-  - sk_test
-channels:
-  - sk_test
+  - sfe1ed40

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,6 @@
+upload_without_merge: true
+
 upload_channels:
-  - sfe1ed40
+  - sk_test
 channels:
-  - sfe1ed40
+  - sk_test

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,8 @@ source:
 build:
   # skip s390x and ppc64le because torchvision does not support these
   skip: True  # [linux and (ppc64le or s390x)]
-  skip: True  # [((osx and x86_64) or win-64) and py>310]
   skip: True  # [py<36]
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
@@ -46,10 +45,10 @@ test:
     - sentence_transformers.models
     - sentence_transformers.models.tokenizer
     - sentence_transformers.readers
-  commands:
-    - pip check
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/UKPLab/sentence-transformers


### PR DESCRIPTION
Requirements: https://github.com/UKPLab/sentence-transformers/blob/v2.2.2/setup.py

Actions: 
- Bump the build number
- Remove `skip: True  # [((osx and x86_64) or win-64) and py>310]` to enable py311 support