### PR TITLE
sentence-transformers 4.1.0 (scikit-learn 1.8.0 rebuild)

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/pbp/fs/scikit-learn-feedstock/pr43/118d43e

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,9 @@ source:
   sha256: 45c3874d1a504ad28ae2f1506589132a4f1ef4378be7271654e4a2db5d9a5b9a
 
 build:
-  skip: True  # [py<39]
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: true  # [py<39]
 
 requirements:
   host:
@@ -24,7 +24,7 @@ requirements:
     - python
     - transformers >=4.41.0,<5.0.0
     - tqdm
-    - pytorch >=1.11.0
+    - pytorch-cpu >=1.11.0
     - scikit-learn
     - scipy
     - huggingface_hub >=0.20.0


### PR DESCRIPTION
sentence-transformers 4.1.0 rebuild

```
Traceback (most recent call last):
  File "/Users/aosipo/miniconda3/conda-bld/sentence-transformers_1765971811549/test_tmp/run_test.py", line 2, in <module>
    import sentence_transformers
  File "/Users/aosipo/miniconda3/conda-bld/sentence-transformers_1765971811549/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pl/lib/python3.12/site-packages/sentence_transformers/__init__.py", line 9, in <module>
    from sentence_transformers.backend import (
  File "/Users/aosipo/miniconda3/conda-bld/sentence-transformers_1765971811549/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pl/lib/python3.12/site-packages/sentence_transformers/backend.py", line 11, in <module>
    from sentence_transformers.util import disable_datasets_caching, is_datasets_available
  File "/Users/aosipo/miniconda3/conda-bld/sentence-transformers_1765971811549/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pl/lib/python3.12/site-packages/sentence_transformers/util.py", line 17, in <module>
    import torch
  File "/Users/aosipo/miniconda3/conda-bld/sentence-transformers_1765971811549/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pl/lib/python3.12/site-packages/torch/__init__.py", line 409, in <module>
    from torch._C import *  # noqa: F403
    ^^^^^^^^^^^^^^^^^^^^^^
ImportError: dlopen(/Users/aosipo/miniconda3/conda-bld/sentence-transformers_1765971811549/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pl/lib/python3.12/site-packages/torch/_C.cpython-312-darwin.so, 0x0002): Symbol not found: __ZN2at3mps14getMPSProfilerEv
  Referenced from: <40CDC379-70F7-3039-81FE-6159FD74FCDA> /Users/aosipo/miniconda3/conda-bld/sentence-transformers_1765971811549/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pl/lib/libtorch_python.dylib
  Expected in:     <EF517B96-4CE4-357A-A9AB-03F243F0861C> /Users/aosipo/miniconda3/conda-bld/sentence-transformers_1765971811549/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pl/lib/libtorch_cpu.dylib
```

For some reason sentence-trnsformers tries automatically use mps gpu version:
```
  pytorch:               2.7.0-gpu_mps_py312h91d4186_200 main
```